### PR TITLE
Update dependencies and refactor random number generation to use `rng…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/mimblewimble/rust-secp256k1-zkp/"
 description = "Grin's fork with Zero-Knowledge extensions of Rust bindings for Pieter Wuille's `libsecp256k1` library. Implements ECDSA for the SECG elliptic curve group secp256k1 and related utilities."
 keywords = [ "crypto", "secp256k1", "grin", "bitcoin", "zero-knowledge" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 build = "build.rs"
 [build-dependencies]
@@ -30,7 +30,7 @@ dev = ["clippy"]
 [dependencies]
 arrayvec = "0.7"
 clippy = {version = "0.0", optional = true}
-rand = "0.5"
+rand = "0.9.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -38,4 +38,4 @@ zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 chrono = "0.4.5"
-rand_core = "0.2"
+rand_core = "0.9.3"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,13 +4,13 @@ name = "grin_secp256k1zkp-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.4.9"
 
 [dependencies.grin_secp256k1zkp]
 path = ".."

--- a/fuzz/fuzz_targets/fuzz_aggsig.rs
+++ b/fuzz/fuzz_targets/fuzz_aggsig.rs
@@ -13,7 +13,7 @@ use secp256k1zkp::{
 };
 
 use secp256k1zkp::aggsig::AggSigContext;
-use secp256k1zkp::rand::{Rng, thread_rng};
+use secp256k1zkp::rand::{Rng, rng};
 
 fuzz_target!(|data: &[u8]| {
     let numkeys = 3;
@@ -21,7 +21,7 @@ fuzz_target!(|data: &[u8]| {
         return ();
     }
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let secp = Secp256k1::with_caps(ContextFlag::Full);
     let mut pks: Vec<PublicKey> = Vec::with_capacity(numkeys);
     let mut keypairs: Vec<(SecretKey, PublicKey)> = Vec::with_capacity(numkeys);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -53,8 +53,10 @@ pub const PEDERSEN_COMMITMENT_SIZE_INTERNAL: usize = 64;
 /// The size of a single Bullet proof
 pub const SINGLE_BULLET_PROOF_SIZE: usize = 675;
 
+/// The size of a single Bullet proof
 #[cfg(feature = "bullet-proof-sizing")]
 pub const MAX_PROOF_SIZE: usize = SINGLE_BULLET_PROOF_SIZE;
+
 /// The max size of a range proof
 #[cfg(not(feature = "bullet-proof-sizing"))]
 pub const MAX_PROOF_SIZE: usize = 5134;
@@ -62,6 +64,8 @@ pub const MAX_PROOF_SIZE: usize = 5134;
 /// The maximum size of a message embedded in a range proof
 #[cfg(not(feature = "bullet-proof-sizing"))]
 pub const PROOF_MSG_SIZE: usize = 2048;
+
+/// The maximum size of a message embedded in a range proof
 #[cfg(feature = "bullet-proof-sizing")]
 pub const PROOF_MSG_SIZE: usize = 2048;
 

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -92,15 +92,15 @@ impl ops::Index<ops::RangeFull> for SharedSecret {
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::rng;
     use super::SharedSecret;
     use super::super::Secp256k1;
 
     #[test]
     fn ecdh() {
         let s = Secp256k1::with_caps(crate::ContextFlag::SignOnly);
-        let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        let (sk2, pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, pk1) = s.generate_keypair(&mut rng()).unwrap();
+        let (sk2, pk2) = s.generate_keypair(&mut rng()).unwrap();
 
         let sec1 = SharedSecret::new(&s, &pk1, &sk2);
         let sec2 = SharedSecret::new(&s, &pk2, &sk1);
@@ -112,7 +112,7 @@ mod tests {
 
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
-    use rand::thread_rng;
+    use rand::rng;
     use test::{Bencher, black_box};
 
     use super::SharedSecret;
@@ -121,7 +121,7 @@ mod benches {
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
         let s = Secp256k1::with_caps(::ContextFlag::SignOnly);
-        let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, pk) = s.generate_keypair(&mut rng()).unwrap();
 
         let s = Secp256k1::new();
         bh.iter( || {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -84,7 +84,7 @@ impl PublicKey {
     /// Create a new (zeroed) public key usable for the FFI interface
     pub fn new() -> PublicKey { PublicKey([0; 64]) }
     /// Create a new (uninitialized) public key usable for the FFI interface
-    pub unsafe fn blank() -> PublicKey { mem::MaybeUninit::uninit().assume_init() }
+    pub unsafe fn blank() -> PublicKey { mem::MaybeUninit::zeroed().assume_init() }
 }
 
 /// Library-internal representation of a Secp256k1 signature
@@ -114,21 +114,21 @@ impl Signature {
     /// Create a signature from raw data
     pub fn from_data(data: [u8; 64]) -> Signature { Signature(data) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> Signature { mem::MaybeUninit::uninit().assume_init() }
+    pub unsafe fn blank() -> Signature { mem::MaybeUninit::zeroed().assume_init() }
 }
 
 impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> RecoverableSignature { mem::MaybeUninit::uninit().assume_init() }
+    pub unsafe fn blank() -> RecoverableSignature { mem::MaybeUninit::zeroed().assume_init() }
 }
 
 impl AggSigPartialSignature {
     /// Create a new (zeroed) aggsig partial signature usable for the FFI interface
     pub fn new() -> AggSigPartialSignature { AggSigPartialSignature([0; 32]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> AggSigPartialSignature { mem::MaybeUninit::uninit().assume_init() }
+    pub unsafe fn blank() -> AggSigPartialSignature { mem::MaybeUninit::zeroed().assume_init() }
 }
 
 /// Library-internal representation of an ECDH shared secret
@@ -141,477 +141,207 @@ impl SharedSecret {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> SharedSecret { SharedSecret([0; 32]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> SharedSecret { mem::MaybeUninit::uninit().assume_init() }
+    pub unsafe fn blank() -> SharedSecret { mem::MaybeUninit::zeroed().assume_init() }
 }
 
 
 extern "C" {
-    pub static secp256k1_nonce_function_rfc6979: NonceFn;
 
+    /// Default nonce function
+    pub static secp256k1_nonce_function_rfc6979: NonceFn;
+    
+    /// Default nonce function
     pub static secp256k1_nonce_function_default: NonceFn;
 
-    // Contexts
+    /// Creates a new context.
     pub fn secp256k1_context_create(flags: c_uint) -> *mut Context;
 
+    /// Clones an existing context.
     pub fn secp256k1_context_clone(cx: *mut Context) -> *mut Context;
 
+    /// Destroys a context.
     pub fn secp256k1_context_destroy(cx: *mut Context);
 
-    pub fn secp256k1_context_randomize(cx: *mut Context,
-                                       seed32: *const c_uchar)
-                                       -> c_int;
-    // Scratch space
-    pub fn secp256k1_scratch_space_create(cx: *mut Context,
-                                          max_size: size_t)
-                                          -> *mut ScratchSpace;
+    /// Randomizes a context.
+    pub fn secp256k1_context_randomize(cx: *mut Context, seed32: *const c_uchar) -> c_int;
 
+    /// Creates a new scratch space.
+    pub fn secp256k1_scratch_space_create(cx: *mut Context, max_size: size_t) -> *mut ScratchSpace;
+
+    /// Destroys a scratch space.
     pub fn secp256k1_scratch_space_destroy(sp: *mut ScratchSpace);
 
-    // Generator
-    pub fn secp256k1_generator_generate(cx: *const Context,
-                                        gen: *mut Generator,
-                                        seed32: *const c_uchar)
-                                        -> c_int;
+    /// Generates a generator.
+    pub fn secp256k1_generator_generate(cx: *const Context, gen: *mut Generator, seed32: *const c_uchar) -> c_int;
 
-    // TODO secp256k1_context_set_illegal_callback
-    // TODO secp256k1_context_set_error_callback
-    // (Actually, I don't really want these exposed; if either of these
-    // are ever triggered it indicates a bug in rust-secp256k1, since
-    // one goal is to use Rust's type system to eliminate all possible
-    // bad inputs.)
+    /// Parses a public key.
+    pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey, input: *const c_uchar, in_len: size_t) -> c_int;
 
-    // Pubkeys
-    pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
-                                     input: *const c_uchar, in_len: size_t)
-                                     -> c_int;
+    /// Serializes a public key.
+    pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *const c_uchar, out_len: *mut size_t, pk: *const PublicKey, compressed: c_uint) -> c_int;
 
-    pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *const c_uchar,
-                                         out_len: *mut size_t, pk: *const PublicKey,
-                                         compressed: c_uint)
-                                         -> c_int;
+    /// Parses a DER-encoded ECDSA signature.
+    pub fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature, input: *const c_uchar, in_len: size_t) -> c_int;
 
-    // Signatures
-    pub fn secp256k1_ecdsa_signature_parse_der(cx: *const Context, sig: *mut Signature,
-                                               input: *const c_uchar, in_len: size_t)
-                                               -> c_int;
+    /// Parses a compact ECDSA signature.
+    pub fn secp256k1_ecdsa_signature_parse_compact(cx: *const Context, sig: *mut Signature, input64: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_parse_compact(cx: *const Context, sig: *mut Signature,
-                                                   input64: *const c_uchar)
-                                                   -> c_int;
+    /// Parses a DER-encoded ECDSA signature with lax rules.
+    pub fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature, input: *const c_uchar, in_len: size_t) -> c_int;
 
-    pub fn ecdsa_signature_parse_der_lax(cx: *const Context, sig: *mut Signature,
-                                         input: *const c_uchar, in_len: size_t)
-                                         -> c_int;
+    /// Serializes an ECDSA signature in DER format.
+    pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *const c_uchar, out_len: *mut size_t, sig: *const Signature) -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *const c_uchar,
-                                                   out_len: *mut size_t, sig: *const Signature)
-                                                   -> c_int;
+    /// Serializes an ECDSA signature in compact format.
+    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *const c_uchar, sig: *const Signature) -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
-                                                       sig: *const Signature)
-                                                       -> c_int;
+    /// Parses a compact recoverable ECDSA signature.
+    pub fn secp256k1_ecdsa_recoverable_signature_parse_compact(cx: *const Context, sig: *mut RecoverableSignature, input64: *const c_uchar, recid: c_int) -> c_int;
 
-    pub fn secp256k1_ecdsa_recoverable_signature_parse_compact(cx: *const Context, sig: *mut RecoverableSignature,
-                                                               input64: *const c_uchar, recid: c_int)
-                                                               -> c_int;
+    /// Serializes a recoverable ECDSA signature in compact format.
+    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *const c_uchar, recid: *mut c_int, sig: *const RecoverableSignature) -> c_int;
 
-    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
-                                                                   recid: *mut c_int, sig: *const RecoverableSignature)
-                                                                   -> c_int;
+    /// Converts a recoverable ECDSA signature to a normal signature.
+    pub fn secp256k1_ecdsa_recoverable_signature_convert(cx: *const Context, sig: *mut Signature, input: *const RecoverableSignature) -> c_int;
 
-    pub fn secp256k1_ecdsa_recoverable_signature_convert(cx: *const Context, sig: *mut Signature,
-                                                         input: *const RecoverableSignature)
-                                                         -> c_int;
+    /// Normalizes an ECDSA signature.
+    pub fn secp256k1_ecdsa_signature_normalize(cx: *const Context, out_sig: *mut Signature, in_sig: *const Signature) -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_normalize(cx: *const Context, out_sig: *mut Signature,
-                                               in_sig: *const Signature)
-                                               -> c_int;
+    /// Verifies an ECDSA signature.
+    pub fn secp256k1_ecdsa_verify(cx: *const Context, sig: *const Signature, msg32: *const c_uchar, pk: *const PublicKey) -> c_int;
 
-    // ECDSA
-    pub fn secp256k1_ecdsa_verify(cx: *const Context,
-                                  sig: *const Signature,
-                                  msg32: *const c_uchar,
-                                  pk: *const PublicKey)
-                                  -> c_int;
+    /// Signs a message with ECDSA.
+    pub fn secp256k1_ecdsa_sign(cx: *const Context, sig: *mut Signature, msg32: *const c_uchar, sk: *const c_uchar, noncefn: NonceFn, noncedata: *const c_void) -> c_int;
 
-    pub fn secp256k1_ecdsa_sign(cx: *const Context,
-                                sig: *mut Signature,
-                                msg32: *const c_uchar,
-                                sk: *const c_uchar,
-                                noncefn: NonceFn,
-                                noncedata: *const c_void)
-                                -> c_int;
+    /// Signs a message with a recoverable ECDSA signature.
+    pub fn secp256k1_ecdsa_sign_recoverable(cx: *const Context, sig: *mut RecoverableSignature, msg32: *const c_uchar, sk: *const c_uchar, noncefn: NonceFn, noncedata: *const c_void) -> c_int;
 
-    pub fn secp256k1_ecdsa_sign_recoverable(cx: *const Context,
-                                            sig: *mut RecoverableSignature,
-                                            msg32: *const c_uchar,
-                                            sk: *const c_uchar,
-                                            noncefn: NonceFn,
-                                            noncedata: *const c_void)
-                                            -> c_int;
+    /// Recovers a public key from a recoverable ECDSA signature.
+    pub fn secp256k1_ecdsa_recover(cx: *const Context, pk: *mut PublicKey, sig: *const RecoverableSignature, msg32: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ecdsa_recover(cx: *const Context,
-                                   pk: *mut PublicKey,
-                                   sig: *const RecoverableSignature,
-                                   msg32: *const c_uchar)
-                                   -> c_int;
-    // AGGSIG (Schnorr) Multisig
-    pub fn secp256k1_aggsig_context_create(cx: *const Context,
-                                           pks: *const PublicKey,
-                                           n_pks: size_t,
-                                           seed32: *const c_uchar)
-                                           -> *mut AggSigContext;
+    /// Creates an aggregated signature context.
+    pub fn secp256k1_aggsig_context_create(cx: *const Context, pks: *const PublicKey, n_pks: size_t, seed32: *const c_uchar) -> *mut AggSigContext;
 
+    /// Destroys an aggregated signature context.
     pub fn secp256k1_aggsig_context_destroy(aggctx: *mut AggSigContext);
 
-    pub fn secp256k1_aggsig_generate_nonce(cx: *const Context,
-                                           aggctx: *mut AggSigContext,
-                                           index: size_t)
-                                           -> c_int;
+    /// Generates a nonce for an aggregated signature.
+    pub fn secp256k1_aggsig_generate_nonce(cx: *const Context, aggctx: *mut AggSigContext, index: size_t) -> c_int;
 
-    pub fn secp256k1_aggsig_partial_sign(cx: *const Context,
-                                         aggctx: *mut AggSigContext,
-                                         sig: *mut AggSigPartialSignature,
-                                         msghash32: *const c_uchar,
-                                         seckey32: *const c_uchar,
-                                         index: size_t)
-                                           -> c_int;
+    /// Generates a partial signature for an aggregated signature.
+    pub fn secp256k1_aggsig_partial_sign(cx: *const Context, aggctx: *mut AggSigContext, sig: *mut AggSigPartialSignature, msghash32: *const c_uchar, seckey32: *const c_uchar, index: size_t) -> c_int;
 
-    pub fn secp256k1_aggsig_combine_signatures(cx: *const Context,
-                                         aggctx: *mut AggSigContext,
-                                         sig64: *mut Signature,
-                                         partial: *const AggSigPartialSignature,
-                                         index: size_t)
-                                           -> c_int;
+    /// Combines partial signatures into a final signature.
+    pub fn secp256k1_aggsig_combine_signatures(cx: *const Context, aggctx: *mut AggSigContext, sig64: *mut Signature, partial: *const AggSigPartialSignature, index: size_t) -> c_int;
 
-    pub fn secp256k1_aggsig_build_scratch_and_verify(cx: *const Context,
-                                                     sig64: *const Signature,
-                                                     msg32: *const c_uchar,
-                                                     pks: *const PublicKey,
-                                                     n_pubkeys: size_t)
-                                                         -> c_int;
+    /// Builds scratch space and verifies an aggregated signature.
+    pub fn secp256k1_aggsig_build_scratch_and_verify(cx: *const Context, sig64: *const Signature, msg32: *const c_uchar, pks: *const PublicKey, n_pubkeys: size_t) -> c_int;
 
-    // AGGSIG (single sig or single-signer Schnorr)
-    pub fn secp256k1_aggsig_export_secnonce_single(cx: *const Context,
-                                                   secnonce32: *mut c_uchar,
-                                                   seed32: *const c_uchar)
-                                                       -> c_int;
+    /// Exports a secret nonce for a single aggregated signature.
+    pub fn secp256k1_aggsig_export_secnonce_single(cx: *const Context, secnonce32: *mut c_uchar, seed32: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_aggsig_sign_single(cx: *const Context,
-                                        sig: *mut Signature,
-                                        msg32: *const c_uchar,
-                                        seckey32: *const c_uchar,
-                                        secnonce32: *const c_uchar,
-                                        extra32: *const c_uchar,
-                                        pubnonce_for_e: *const PublicKey,
-                                        pubnonce_total: *const PublicKey,
-                                        pubkey_for_e: *const PublicKey,
-                                        seed32: *const c_uchar)
-                                           -> c_int;
+    /// Signs a single aggregated signature.
+    pub fn secp256k1_aggsig_sign_single(cx: *const Context, sig: *mut Signature, msg32: *const c_uchar, seckey32: *const c_uchar, secnonce32: *const c_uchar, extra32: *const c_uchar, pubnonce_for_e: *const PublicKey, pubnonce_total: *const PublicKey, pubkey_for_e: *const PublicKey, seed32: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_aggsig_verify_single(cx: *const Context,
-                                          sig: *const Signature,
-                                          msg32: *const c_uchar,
-                                          pubnonce: *const PublicKey,
-                                          pk: *const PublicKey,
-                                          pk_total: *const PublicKey,
-                                          extra_pubkey: *const PublicKey,
-                                          is_partial: c_uint)
-                                           -> c_int;
+    /// Verifies a single aggregated signature.
+    pub fn secp256k1_aggsig_verify_single(cx: *const Context, sig: *const Signature, msg32: *const c_uchar, pubnonce: *const PublicKey, pk: *const PublicKey, pk_total: *const PublicKey, extra_pubkey: *const PublicKey, is_partial: c_uint) -> c_int;
 
-    pub fn secp256k1_schnorrsig_verify_batch(cx: *const Context,
-                                             scratch: *mut ScratchSpace,
-                                             sig: *const *const c_uchar,
-                                             msg32: *const *const c_uchar,
-                                             pk: *const *const PublicKey,
-                                             n_sigs: size_t)
-                                               -> c_int;
+    /// Verifies a batch of Schnorr signatures.
+    pub fn secp256k1_schnorrsig_verify_batch(cx: *const Context, scratch: *mut ScratchSpace, sig: *const *const c_uchar, msg32: *const *const c_uchar, pk: *const *const PublicKey, n_sigs: size_t) -> c_int;
 
-    pub fn secp256k1_aggsig_add_signatures_single(cx: *const Context,
-                                                  ret_sig: *mut Signature,
-                                                  sigs: *const *const c_uchar,
-                                                  num_sigs: size_t,
-                                                  pubnonce_total: *const PublicKey)
-                                                      -> c_int;
+    /// Adds signatures for a single aggregated signature.
+    pub fn secp256k1_aggsig_add_signatures_single(cx: *const Context, ret_sig: *mut Signature, sigs: *const *const c_uchar, num_sigs: size_t, pubnonce_total: *const PublicKey) -> c_int;
 
-    pub fn secp256k1_aggsig_subtract_partial_signature(cx: *const Context,
-                                                  ret_partsig: *mut Signature,
-                                                  ret_partsig_alt: *mut Signature,
-                                                  sig: *const Signature,
-                                                  part_sig: *const Signature)
-                                                      -> c_int;
+    /// Subtracts a partial signature from another signature.
+    pub fn secp256k1_aggsig_subtract_partial_signature(cx: *const Context, ret_partsig: *mut Signature, ret_partsig_alt: *mut Signature, sig: *const Signature, part_sig: *const Signature) -> c_int;
 
-     // EC
-    pub fn secp256k1_ec_seckey_verify(cx: *const Context,
-                                      sk: *const c_uchar) -> c_int;
+    /// Verifies a secret key.
+    pub fn secp256k1_ec_seckey_verify(cx: *const Context, sk: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_pubkey_create(cx: *const Context, pk: *mut PublicKey,
-                                      sk: *const c_uchar) -> c_int;
+    /// Creates a public key from a secret key.
+    pub fn secp256k1_ec_pubkey_create(cx: *const Context, pk: *mut PublicKey, sk: *const c_uchar) -> c_int;
 
-//TODO secp256k1_ec_privkey_export
-//TODO secp256k1_ec_privkey_import
+    /// Adds a tweak to a secret key.
+    pub fn secp256k1_ec_privkey_tweak_add(cx: *const Context, sk: *mut c_uchar, tweak: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_privkey_tweak_add(cx: *const Context,
-                                          sk: *mut c_uchar,
-                                          tweak: *const c_uchar)
-                                          -> c_int;
+    /// Adds a tweak to a public key.
+    pub fn secp256k1_ec_pubkey_tweak_add(cx: *const Context, pk: *mut PublicKey, tweak: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_pubkey_tweak_add(cx: *const Context,
-                                         pk: *mut PublicKey,
-                                         tweak: *const c_uchar)
-                                         -> c_int;
+    /// Multiplies a secret key by a tweak.
+    pub fn secp256k1_ec_privkey_tweak_mul(cx: *const Context, sk: *mut c_uchar, tweak: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_privkey_tweak_mul(cx: *const Context,
-                                          sk: *mut c_uchar,
-                                          tweak: *const c_uchar)
-                                          -> c_int;
+    /// Multiplies a public key by a tweak.
+    pub fn secp256k1_ec_pubkey_tweak_mul(cx: *const Context, pk: *mut PublicKey, tweak: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_pubkey_tweak_mul(cx: *const Context,
-                                         pk: *mut PublicKey,
-                                         tweak: *const c_uchar)
-                                         -> c_int;
+    /// Combines multiple public keys into one.
+    pub fn secp256k1_ec_pubkey_combine(cx: *const Context, out: *mut PublicKey, ins: *const *const PublicKey, n: c_int) -> c_int;
 
-    pub fn secp256k1_ec_pubkey_combine(cx: *const Context,
-                                       out: *mut PublicKey,
-                                       ins: *const *const PublicKey,
-                                       n: c_int)
-                                       -> c_int;
+    /// Inverts a secret key.
+    pub fn secp256k1_ec_privkey_tweak_inv(cx: *const Context, sk: *mut c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_privkey_tweak_inv(cx: *const Context,
-                                          sk: *mut c_uchar)
-                                          -> c_int;
+    /// Negates a secret key.
+    pub fn secp256k1_ec_privkey_tweak_neg(cx: *const Context, sk: *mut c_uchar) -> c_int;
 
-    pub fn secp256k1_ec_privkey_tweak_neg(cx: *const Context,
-                                          sk: *mut c_uchar)
-                                          -> c_int;
+    /// Computes an ECDH shared secret.
+    pub fn secp256k1_ecdh(cx: *const Context, out: *mut SharedSecret, point: *const PublicKey, scalar: *const c_uchar) -> c_int;
 
-    pub fn secp256k1_ecdh(cx: *const Context,
-                          out: *mut SharedSecret,
-                          point: *const PublicKey,
-                          scalar: *const c_uchar)
-                          -> c_int;
+    /// Parses a Pedersen commitment.
+    pub fn secp256k1_pedersen_commitment_parse(cx: *const Context, commit: *mut c_uchar, input: *const c_uchar) -> c_int;
 
-  // Parse a 33-byte commitment into 64 byte internal commitment object
-  pub fn secp256k1_pedersen_commitment_parse(cx: *const Context,
-                                              commit: *mut c_uchar,
-                                              input: *const c_uchar)
-                                              -> c_int;
+    /// Serializes a Pedersen commitment.
+    pub fn secp256k1_pedersen_commitment_serialize(cx: *const Context, output: *mut c_uchar, commit: *const c_uchar) -> c_int;
 
-  // Serialize a 64-byte commit object into a 33 byte serialized byte sequence
-  pub fn secp256k1_pedersen_commitment_serialize(cx: *const Context,
-                                                  output: *mut c_uchar,
-                                                  commit: *const c_uchar)
-                                                  -> c_int;
+    /// Generates a Pedersen commitment.
+    pub fn secp256k1_pedersen_commit(cx: *const Context, commit: *mut c_uchar, blind: *const c_uchar, value: u64, value_gen: *const c_uchar, blind_gen: *const c_uchar) -> c_int;
 
+    /// Generates a Pedersen commitment with a blind value.
+    pub fn secp256k1_pedersen_blind_commit(cx: *const Context, commit: *mut c_uchar, blind: *const c_uchar, value: *const c_uchar, value_gen: *const c_uchar, blind_gen: *const c_uchar) -> c_int;
 
-	// Generates a pedersen commitment: *commit = blind * G + value * G2.
-	// The commitment is 33 bytes, the blinding factor is 32 bytes.
-	pub fn secp256k1_pedersen_commit(
-		ctx: *const Context,
-		commit: *mut c_uchar,
-		blind: *const c_uchar,
-		value: u64,
-		value_gen: *const c_uchar,
-		blind_gen: *const c_uchar
-	) -> c_int;
+    /// Converts a Pedersen commitment to a public key.
+    pub fn secp256k1_pedersen_commitment_to_pubkey(cx: *const Context, pk: *mut PublicKey, commit: *const c_uchar) -> c_int;
 
-	// Generates a pedersen commitment: *commit = blind * G + value * G2.
-	// The commitment is 33 bytes, the blinding factor and the value are 32 bytes.
-	pub fn secp256k1_pedersen_blind_commit(
-		ctx: *const Context,
-		commit: *mut c_uchar,
-		blind: *const c_uchar,
-		value: *const c_uchar,
-		value_gen: *const c_uchar,
-		blind_gen: *const c_uchar
-	) -> c_int;
+    /// Converts a public key to a Pedersen commitment.
+    pub fn secp256k1_pubkey_to_pedersen_commitment(cx: *const Context, commit: *mut c_uchar, pk: *const PublicKey) -> c_int;
 
-	// Get the public key of a pedersen commitment
-	pub fn secp256k1_pedersen_commitment_to_pubkey(
-	    cx: *const Context, pk: *mut PublicKey,
-	    commit: *const c_uchar) -> c_int;
+    /// Computes a sum of Pedersen blinding factors.
+    pub fn secp256k1_pedersen_blind_sum(cx: *const Context, blind_out: *const c_uchar, blinds: *const *const c_uchar, n: size_t, npositive: size_t) -> c_int;
 
-	// Get a pedersen commitment from a pubkey
-	pub fn secp256k1_pubkey_to_pedersen_commitment(
-	    cx: *const Context, commit: *mut c_uchar,
-	    pk: *const PublicKey) -> c_int;
+    /// Computes a sum of Pedersen commitments.
+    pub fn secp256k1_pedersen_commit_sum(cx: *const Context, commit_out: *const c_uchar, commits: *const *const c_uchar, pcnt: size_t, ncommits: *const *const c_uchar, ncnt: size_t) -> c_int;
 
-	// Takes a list of n pointers to 32 byte blinding values, the first negs
-	// of which are treated with positive sign and the rest negative, then
-	// calculates an additional blinding value that adds to zero.
-	pub fn secp256k1_pedersen_blind_sum(
-		ctx: *const Context,
-		blind_out: *const c_uchar,
-		blinds: *const *const c_uchar,
-		n: size_t,
-		npositive: size_t
-	) -> c_int;
+    /// Calculates a blinding factor for a switch commitment.
+    pub fn secp256k1_blind_switch(cx: *const Context, blind_switch: *mut c_uchar, blind: *const c_uchar, value: u64, value_gen: *const c_uchar, blind_gen: *const c_uchar, switch_pubkey: *const c_uchar) -> c_int;
 
-	// Takes two list of 64-byte commitments and sums the first set, subtracts
-	// the second and returns the resulting commitment.
-	pub fn secp256k1_pedersen_commit_sum(
-		ctx: *const Context,
-		commit_out: *const c_uchar,
-		commits: *const *const c_uchar,
-		pcnt: size_t,
-		ncommits: *const *const c_uchar,
-		ncnt: size_t
-	) -> c_int;
+    /// Verifies a tally of Pedersen commitments.
+    pub fn secp256k1_pedersen_verify_tally(cx: *const Context, commits: *const *const c_uchar, pcnt: size_t, ncommits: *const *const c_uchar, ncnt: size_t) -> c_int;
 
-    // Calculate blinding factor for switch commitment x + H(xG+vH | xJ)
-    pub fn secp256k1_blind_switch(
-        ctx: *const Context,
-        blind_switch: *mut c_uchar,
-        blind: *const c_uchar,
-        value: u64,
-        value_gen: *const c_uchar,
-        blind_gen: *const c_uchar,
-        switch_pubkey: *const c_uchar
-    ) -> c_int;
+    /// Retrieves information about a range proof.
+    pub fn secp256k1_rangeproof_info(cx: *const Context, exp: *mut c_int, mantissa: *mut c_int, min_value: *mut u64, max_value: *mut u64, proof: *const c_uchar, plen: size_t) -> c_int;
 
-	// Takes two list of 64-byte commitments and sums the first set and
-	// subtracts the second and verifies that they sum to 0.
-	pub fn secp256k1_pedersen_verify_tally(ctx: *const Context,
-		commits: *const *const c_uchar,
-		pcnt: size_t,
-		ncommits: *const *const c_uchar,
-		ncnt: size_t
-	) -> c_int;
+    /// Rewinds a range proof.
+    pub fn secp256k1_rangeproof_rewind(cx: *const Context, blind_out: *mut c_uchar, value_out: *mut u64, message_out: *mut c_uchar, outlen: *mut size_t, nonce: *const c_uchar, min_value: *mut u64, max_value: *mut u64, commit: *const c_uchar, proof: *const c_uchar, plen: size_t, extra_commit: *const c_uchar, extra_commit_len: size_t, gen: *const c_uchar) -> c_int;
 
-	pub fn secp256k1_rangeproof_info(
-		ctx: *const Context,
-		exp: *mut c_int,
-		mantissa: *mut c_int,
-		min_value: *mut u64,
-		max_value: *mut u64,
-		proof: *const c_uchar,
-		plen: size_t
-	) -> c_int;
+    /// Verifies a range proof.
+    pub fn secp256k1_rangeproof_verify(cx: *const Context, min_value: &mut u64, max_value: &mut u64, commit: *const c_uchar, proof: *const c_uchar, plen: size_t, extra_commit: *const c_uchar, extra_commit_len: size_t, gen: *const c_uchar) -> c_int;
 
-	pub fn secp256k1_rangeproof_rewind(
-		ctx: *const Context,
-		blind_out: *mut c_uchar,
-		value_out: *mut u64,
-		message_out: *mut c_uchar,
-		outlen: *mut size_t,
-		nonce: *const c_uchar,
-		min_value: *mut u64,
-		max_value: *mut u64,
-		commit: *const c_uchar,
-		proof: *const c_uchar,
-		plen: size_t,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		gen: *const c_uchar
-	) -> c_int;
+    /// Signs a range proof.
+    pub fn secp256k1_rangeproof_sign(cx: *const Context, proof: *mut c_uchar, plen: *mut size_t, min_value: u64, commit: *const c_uchar, blind: *const c_uchar, nonce: *const c_uchar, exp: c_int, min_bits: c_int, value: u64, message: *const c_uchar, msg_len: size_t, extra_commit: *const c_uchar, extra_commit_len: size_t, gen: *const c_uchar) -> c_int;
 
-	pub fn secp256k1_rangeproof_verify(
-		ctx: *const Context,
-		min_value: &mut u64,
-		max_value: &mut u64,
-		commit: *const c_uchar,
-		proof: *const c_uchar,
-		plen: size_t,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		gen: *const c_uchar
-	) -> c_int;
+    /// Creates bulletproof generators.
+    pub fn secp256k1_bulletproof_generators_create(ctx: *const Context, blinding_gen: *const c_uchar, n: size_t) -> *mut BulletproofGenerators;
 
-	pub fn secp256k1_rangeproof_sign(
-		ctx: *const Context,
-		proof: *mut c_uchar,
-		plen: *mut size_t,
-		min_value: u64,
-		commit: *const c_uchar,
-		blind: *const c_uchar,
-		nonce: *const c_uchar,
-		exp: c_int,
-		min_bits: c_int,
-		value: u64,
-		message: *const c_uchar,
-		msg_len: size_t,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		gen: *const c_uchar
-	) -> c_int;
+    /// Destroys bulletproof generators.
+    pub fn secp256k1_bulletproof_generators_destroy(ctx: *const Context, gen: *mut BulletproofGenerators);
 
-	pub fn secp256k1_bulletproof_generators_create(
-		ctx: *const Context,
-		blinding_gen: *const c_uchar,
-		n: size_t,
-	) -> *mut BulletproofGenerators;
+    /// Proves a bulletproof range proof.
+    pub fn secp256k1_bulletproof_rangeproof_prove(ctx: *const Context, scratch: *mut ScratchSpace, gens: *const BulletproofGenerators, proof: *mut c_uchar, plen: *mut size_t, tau_x: *mut c_uchar, t_one: *mut PublicKey, t_two: *mut PublicKey, value: *const u64, min_value: *const u64, blind: *const *const c_uchar, commits: *const *const c_uchar, n_commits: size_t, value_gen: *const c_uchar, nbits: size_t, nonce: *const c_uchar, private_nonce: *const c_uchar, extra_commit: *const c_uchar, extra_commit_len: size_t, message: *const c_uchar) -> c_int;
 
-	pub fn secp256k1_bulletproof_generators_destroy(
-		ctx: *const Context,
-		gen: *mut BulletproofGenerators,
-	);
+    /// Verifies a bulletproof range proof.
+    pub fn secp256k1_bulletproof_rangeproof_verify(ctx: *const Context, scratch: *mut ScratchSpace, gens: *const BulletproofGenerators, proof: *const c_uchar, plen: size_t, min_value: *const u64, commit: *const c_uchar, n_commits: size_t, nbits: size_t, value_gen: *const c_uchar, extra_commit: *const c_uchar, extra_commit_len: size_t) -> c_int;
 
-	pub fn secp256k1_bulletproof_rangeproof_prove(
-		ctx: *const Context,
-		scratch: *mut ScratchSpace,
-		gens: *const BulletproofGenerators,
-		proof: *mut c_uchar,
-		plen: *mut size_t,
-		tau_x: *mut c_uchar,
-		t_one: *mut PublicKey,
-		t_two: *mut PublicKey,
-		value: *const u64,
-		min_value: *const u64,
-		blind: *const *const c_uchar,
-		commits: *const *const c_uchar,
-		n_commits: size_t,
-		value_gen: *const c_uchar,
-		nbits: size_t,
-		nonce: *const c_uchar,
-		private_nonce: *const c_uchar,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		message: *const c_uchar,
-	) -> c_int;
+    /// Verifies multiple bulletproof range proofs.
+    pub fn secp256k1_bulletproof_rangeproof_verify_multi(ctx: *const Context, scratch: *mut ScratchSpace, gens: *const BulletproofGenerators, proofs: *const *const c_uchar, n_proofs: size_t, plen: size_t, min_value: *const *const u64, commits: *const *const c_uchar, n_commits: size_t, nbits: size_t, value_gen: *const c_uchar, extra_commit: *const *const c_uchar, extra_commit_len: *const size_t) -> c_int;
 
-	pub fn secp256k1_bulletproof_rangeproof_verify(
-		ctx: *const Context,
-		scratch: *mut ScratchSpace,
-		gens: *const BulletproofGenerators,
-		proof: *const c_uchar,
-		plen: size_t,
-		min_value: *const u64,
-		commit: *const c_uchar,
-		n_commits: size_t,
-		nbits: size_t,
-		value_gen: *const c_uchar,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t
-	) -> c_int;
-
-	pub fn secp256k1_bulletproof_rangeproof_verify_multi(
-		ctx: *const Context,
-		scratch: *mut ScratchSpace,
-		gens: *const BulletproofGenerators,
-		proofs: *const *const c_uchar,
-		n_proofs: size_t,
-		plen: size_t,
-		min_value: *const *const u64,
-		commits: *const *const c_uchar,
-		n_commits: size_t,
-		nbits: size_t,
-		value_gen: *const c_uchar,
-		extra_commit: *const *const c_uchar,
-		extra_commit_len: *const size_t
-	) -> c_int;
-
-	pub fn secp256k1_bulletproof_rangeproof_rewind(
-		ctx: *const Context,
-		value: *mut u64,
-		blind: *mut c_uchar,
-		proof: *const c_uchar,
-		plen: size_t,
-		min_value: u64,
-		commit: *const c_uchar,
-		value_gen: *const c_uchar,
-		nonce: *const c_uchar,
-		extra_commit: *const c_uchar,
-		extra_commit_len: size_t,
-		message: *mut c_uchar,
-	) -> c_int;
+    /// Rewinds a bulletproof range proof.
+    pub fn secp256k1_bulletproof_rangeproof_rewind(ctx: *const Context, value: *mut u64, blind: *mut c_uchar, proof: *const c_uchar, plen: size_t, min_value: u64, commit: *const c_uchar, value_gen: *const c_uchar, nonce: *const c_uchar, extra_commit: *const c_uchar, extra_commit_len: size_t, message: *mut c_uchar) -> c_int;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -75,11 +75,11 @@ macro_rules! impl_array_newtype {
                 unsafe {
                     use std::ptr::copy_nonoverlapping;
                     use std::mem;
-                    let mut ret: $thing = mem::MaybeUninit::uninit().assume_init();
+                    let mut ret = mem::MaybeUninit::<$thing>::uninit();
                     copy_nonoverlapping(self.as_ptr(),
-                                        ret.as_mut_ptr(),
+                                        (*ret.as_mut_ptr()).as_mut_ptr(),
                                         mem::size_of::<$thing>());
-                    ret
+                    ret.assume_init()
                 }
             }
         }
@@ -160,9 +160,11 @@ macro_rules! impl_array_newtype {
                     fn visit_seq<A>(self, mut a: A) -> Result<$thing, A::Error>
                         where A: ::serde::de::SeqAccess<'de>
                     {
-                        unsafe {
-                            use std::mem;
-                            let mut ret: [$ty; $len] = mem::MaybeUninit::uninit().assume_init();
+                        
+                           
+                            let mut ret: [$ty; $len] = [0; $len];
+                            
+                            
                             for i in 0..$len {
                                 ret[i] = match a.next_element()? {
                                     Some(c) => c,
@@ -174,7 +176,7 @@ macro_rules! impl_array_newtype {
                                 return Err(::serde::de::Error::invalid_length($len + 1, &self));
                             }
                             Ok($thing(ret))
-                        }
+                        
                     }
 
                     fn expecting(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {


### PR DESCRIPTION
…()instead ofthread_rng()This pull request updates the codebase to use Rust 2021 edition, modernizes dependencies, and replaces the deprecatedthread_rngfunction with therngfunction from therand` crate. Additionally, it removes unsafe code in key deserialization and includes minor refactoring for clarity. Below are the most important changes grouped by theme:

Dependency Updates

Updated the Rust edition from 2018 to 2021 in Cargo.toml and fuzz/Cargo.toml for modern language features. [[1]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R14) [[2]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-adb6b77ef7d25080f602acb615fefc7d47e8e1321ee09759aae8a4eba6c4ae4bL7-R13)
Upgraded rand from version 0.5 to 0.9.0 and rand_core from version 0.2 to 0.9.3 in Cargo.toml.
Updated libfuzzer-sys dependency from 0.3 to 0.4.9 in fuzz/Cargo.toml.
Transition to rng from thread_rng

Replaced all instances of thread_rng with rng across the codebase for compatibility with the updated rand crate. This includes changes in src/aggsig.rs, src/ecdh.rs, src/key.rs, and fuzz/fuzz_targets/fuzz_aggsig.rs. [[1]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-b383dc98651da917e85dedc337a03468cb35ba52cf2c76655fca10f546e5f293L16-R24) [[2]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-9c0e014bd06106b08761faa9c94468759bf8c3ea7b7697ec46478629ac005a69L19-R19) [[3]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-2ada98d540e88906bfe287caa999ddd6afa38d46fc8733ce014857d4cdd5801eL95-R103) [[4]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L376-R375)
Removal of Unsafe Code

Eliminated unsafe initialization of arrays in the Deserialize implementation for PublicKey in src/key.rs, replacing it with a safe zeroed array initialization. [[1]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L317-R318) [[2]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L345-R344)
Minor Refactoring

Commented out unused try_fill_bytes methods in the test module of src/key.rs for improved code clarity. [[1]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L585-R586) [[2]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L628-R627) [[3]](https://github.com/mimblewimble/rust-secp256k1-zkp/pull/86/files#diff-0988d5d2259e1a401001675578c38d09c46290b877b66b07fb96a7e034ccdf70L652-R651)
Documentation and Constants

Added and clarified comments for constants related to Bulletproofs and range proofs in src/constants.rs.